### PR TITLE
Adds charset for babel script

### DIFF
--- a/global-react/index.html
+++ b/global-react/index.html
@@ -12,7 +12,8 @@
     <script src="https://unpkg.com/react-dom@16.0.0-beta.2/umd/react-dom.production.min.js"
       integrity="sha384-urrH8a5NtX87DSmFO4pKPICl5RHszNM6yx75JIYhynT2ukWDK4skf0YAh4EDEdD2"
       crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/babel-standalone@6.24.2/babel.min.js"></script>
+    <script src="https://unpkg.com/babel-standalone@6.24.2/babel.min.js"
+      charset="utf-8"></script>
 
     <script type="text/babel">
       class MyApp extends React.Component {


### PR DESCRIPTION
Without charset on the babel script tag I'm seeing an error:

```
Uncaught SyntaxError: Invalid regular expression: /[ÂªÂµÂºÃ€-Ã–Ã˜-Ã¶Ã¸-ËË†-Ë‘Ë -Ë¤Ë¬Ë®Í°-Í´Í¶Í·Íº-Í½Í¿Î†Îˆ-ÎŠÎŒÎŽ-Î¡Î£...
```